### PR TITLE
Make sidebar fixed

### DIFF
--- a/static/css/stgit.css
+++ b/static/css/stgit.css
@@ -194,6 +194,10 @@ body > div > header {
     position: fixed;
     height: 100%;
   }
+
+	body > div > div {
+		margin-left: 12rem;
+	}
 }
 
 body > div > header > a > img {

--- a/static/css/stgit.css
+++ b/static/css/stgit.css
@@ -189,6 +189,13 @@ body > div > header {
     padding-top: var(--s3);
 }
 
+@media (min-width: 768px) {
+  body > div > header {
+    position: fixed;
+    height: 100%;
+  }
+}
+
 body > div > header > a > img {
     width: 33%;
 }

--- a/static/css/stgit.css
+++ b/static/css/stgit.css
@@ -195,9 +195,10 @@ body > div > header {
     height: 100%;
   }
 
-	body > div > div {
-		margin-left: 12rem;
-	}
+  body > div > div {
+    margin-left: 12rem;
+  }
+
 }
 
 body > div > header > a > img {


### PR DESCRIPTION
This pull make the sidebar fixed, eliminating the need to scroll all the way up to change pages. With this change, users can easily access the sidebar navigation while browsing through the content.

This change only affects desktop users, and the mobile experience remains the same as before.


### Before
https://user-images.githubusercontent.com/51955049/222621287-7e057de8-0875-4ae4-8745-35c6ed250bfe.mp4


### After

https://user-images.githubusercontent.com/51955049/222621310-a1e538c7-6d72-4440-87c4-1c16404f49e8.mp4



(Sorry for the low quality videos, i don't know how to setup OBS properly)
